### PR TITLE
DAT-7604 - Wait for future to resolve

### DIFF
--- a/functions/consume-email/emailprocessor/emailprocessor.py
+++ b/functions/consume-email/emailprocessor/emailprocessor.py
@@ -250,10 +250,8 @@ class EmailProcessor(object):
             future = publisher.publish(
                 topic_path, bytes(json.dumps(pubsub_message).encode("utf-8"))
             )
-            future.add_done_callback(
-                lambda x: logging.debug(f"Published email with ID {message['id']}")
-            )
-            logging.info(f"Publishing email with ID {message['id']}")
+            logging.debug(f"Publishing email with ID {message['id']}")
+            logging.info(f"Published email with ID {message['id']}: {future.result()}")
             return True
         except Exception as e:
             logging.exception(


### PR DESCRIPTION
- Added a future.result() call to resolve the future before exiting the function.
- Removed callback; now waiting for future to complete.
- Switched message log levels to make more sense.